### PR TITLE
(fix): Export csv in pagination

### DIFF
--- a/src/pages/admin/AdminLeads.tsx
+++ b/src/pages/admin/AdminLeads.tsx
@@ -92,10 +92,7 @@ const AdminLeads: React.FC = () => {
         setDateFilters(date)
     }
     const exportToCSV = async () => {
-        const indexOfLastItem = currentPage * itemsPerPage;
-        const indexOfFirstItem = indexOfLastItem - itemsPerPage;
-        const filteredPacientes: CreateLeadDTO[] = pacientes.slice(indexOfFirstItem, indexOfLastItem);
-        const exportData = filteredPacientes.map((lead) => ({
+        const exportData = pacientes.map((lead) => ({
             Nome: lead.name || 'Sem Registro',
             Telefone: lead.phoneNumber || 'Sem Registro',
             Canal: canal.find(item => item.id == Number(lead.canal))?.canal || 'Sem Registro',


### PR DESCRIPTION
This pull request simplifies the `exportToCSV` function in the `AdminLeads` component by removing unnecessary pagination logic and exporting all available data.

Simplification of the `exportToCSV` function:

* [`src/pages/admin/AdminLeads.tsx`](diffhunk://#diff-211b29e60c485f9a2e497423173f6fbf3ff7efc1200708561b3da473d3b03398L95-R95): Removed the logic that sliced the `pacientes` array based on pagination (`currentPage` and `itemsPerPage`) and updated the function to map over the entire `pacientes` array for CSV export.